### PR TITLE
feat: Complete M0 infrastructure with Glue and IAM

### DIFF
--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -5,7 +5,7 @@
 # Main bucket
 resource "aws_s3_bucket" "data_lake" {
   bucket = local.bucket_name
-  
+
   tags = {
     Name        = "Market Data Lake"
     Description = "Data lake for market data ETL pipeline"
@@ -15,7 +15,7 @@ resource "aws_s3_bucket" "data_lake" {
 # Block all public access (security best practice)
 resource "aws_s3_bucket_public_access_block" "data_lake" {
   bucket = aws_s3_bucket.data_lake.id
-  
+
   block_public_acls       = true
   block_public_policy     = true
   ignore_public_acls      = true
@@ -25,7 +25,7 @@ resource "aws_s3_bucket_public_access_block" "data_lake" {
 # Enable versioning (data protection)
 resource "aws_s3_bucket_versioning" "data_lake" {
   bucket = aws_s3_bucket.data_lake.id
-  
+
   versioning_configuration {
     status = "Enabled"
   }
@@ -34,7 +34,7 @@ resource "aws_s3_bucket_versioning" "data_lake" {
 # Server-side encryption (security requirement)
 resource "aws_s3_bucket_server_side_encryption_configuration" "data_lake" {
   bucket = aws_s3_bucket.data_lake.id
-  
+
   rule {
     apply_server_side_encryption_by_default {
       sse_algorithm = "AES256"
@@ -45,31 +45,137 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "data_lake" {
 # Lifecycle policy - archive raw data to Glacier after 90 days (cost optimization)
 resource "aws_s3_bucket_lifecycle_configuration" "data_lake" {
   bucket = aws_s3_bucket.data_lake.id
-  
+
   rule {
     id     = "archive-raw-to-glacier"
     status = "Enabled"
-    
+
     filter {
       prefix = "raw/"
     }
-    
+
     transition {
       days          = 90
       storage_class = "GLACIER"
     }
   }
-  
+
   rule {
     id     = "expire-temp-files"
     status = "Enabled"
-    
+
     filter {
       prefix = "temp/"
     }
-    
+
     expiration {
       days = 7
     }
   }
+}
+
+#######################################
+# Glue Data Catalog Database
+#######################################
+
+resource "aws_glue_catalog_database" "market_data" {
+  name        = "market_data"
+  description = "Data catalog for market data ETL pipeline - stores metadata for trades, klines, and other market data tables"
+
+  # Default location for tables in this database
+  location_uri = "s3://${aws_s3_bucket.data_lake.id}/processed/"
+
+  tags = {
+    Name        = "Market Data Catalog"
+    Description = "Glue catalog database for Athena queries and ETL jobs"
+  }
+}
+
+#######################################
+# IAM Role for Glue Jobs
+#######################################
+
+# IAM Role for Glue ETL Jobs
+resource "aws_iam_role" "glue_job_role" {
+  name        = "${var.project_name}-${var.environment}-glue-job-role"
+  description = "IAM role for Glue ETL jobs to access S3 and Glue Catalog"
+
+  # Trust policy - allows Glue service to assume this role
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "glue.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+
+  tags = {
+    Name        = "Glue Job Role"
+    Description = "Service role for Glue ETL jobs"
+  }
+}
+
+# Attach AWS-managed Glue service policy
+resource "aws_iam_role_policy_attachment" "glue_service_policy" {
+  role       = aws_iam_role.glue_job_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole"
+}
+
+# Custom inline policy for S3 data lake access
+resource "aws_iam_role_policy" "glue_s3_access" {
+  name = "s3-data-lake-access"
+  role = aws_iam_role.glue_job_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:DeleteObject"
+        ]
+        Resource = [
+          "${aws_s3_bucket.data_lake.arn}/*"
+        ]
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:ListBucket",
+          "s3:GetBucketLocation"
+        ]
+        Resource = [
+          aws_s3_bucket.data_lake.arn
+        ]
+      }
+    ]
+  })
+}
+
+# CloudWatch Logs permissions for Glue job logging
+resource "aws_iam_role_policy" "glue_cloudwatch_logs" {
+  name = "cloudwatch-logs-access"
+  role = aws_iam_role.glue_job_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ]
+        Resource = "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws-glue/*"
+      }
+    ]
+  })
 }

--- a/infra/terraform/providers.tf
+++ b/infra/terraform/providers.tf
@@ -1,7 +1,7 @@
 # Terraform version and required providers
 terraform {
   required_version = ">= 1.0"
-  
+
   required_providers {
     aws = {
       source  = "hashicorp/aws"
@@ -13,7 +13,7 @@ terraform {
 # AWS Provider configuration
 provider "aws" {
   region = var.aws_region
-  
+
   # Auto-tag all resources
   default_tags {
     tags = {


### PR DESCRIPTION
- Add aws_glue_catalog_database for market_data catalog
- Add IAM role for Glue jobs with trust policy
- Add S3 access policy for Glue (least privilege)
- Add CloudWatch logs policy for Glue job logging
- Attach AWSGlueServiceRole managed policy
- Lock Terraform provider versions in .terraform.lock.hcl
- Format all Terraform files with terraform fmt

Infrastructure successfully applied:
- 10 AWS resources created
- S3 bucket: market-data-etl-dev-....
- Glue database: market_data
- IAM role: market-data-etl-dev-glue-job-role

Verified all resources in AWS Console